### PR TITLE
Feature/help fixup

### DIFF
--- a/Commands.js
+++ b/Commands.js
@@ -26,7 +26,7 @@ module.exports = function(commandSource){
   //Upcoming command
   new Command("upcoming",commandSource)
     .addHandler("","Posts the next upcoming meet",notImplemented,Command.nArgs(0))
-    .addHandler("{location}...","Posts the next upcoming meet at any of the given locations",notImplemented,Command.atleastArgs(1));
+    .addHandler("_location(s)_","Filters the meets to the given locations",notImplemented,Command.atleastArgs(1));
 
   //Easter egg
   new Command("⬆⬆⬇⬇⬅➡⬅➡ba",commandSource)

--- a/Ship/Commands/Help.js
+++ b/Ship/Commands/Help.js
@@ -34,17 +34,16 @@ function buildDesciptions(name,command,deep){
     return;
   }
   if(handlers.length === 0){
-    return deep?`*${name}* - Not a known command\n`:"";
+    return deep?`/${name} - Not a known command\n`:"";
   }
   if(handlers.length === 1){
     return deep?
-      `*${name}* ${handlers[0].args}\n${handlers[0].description}\n`:
-      `*${name}* ${handlers[0].args}\n`;
+      `/${name} ${handlers[0].args}\n  ${handlers[0].description}\n`:
+      `/${name} ${handlers[0].args}\n`;
   }
-  let result = `*${name}*:\n`;
-  handlers.forEach(handle=> result += "> " +
-    (handle.args?handle.args:"_no arguments_") +
-    `: ${handle.description}\n`
+  let result = `/${name}:\n`;
+  handlers.forEach(handle => result +=
+    `  ${handle.args?handle.args+": ":""}${handle.description}\n`
   );
   return result;
 }

--- a/Ship/Commands/Help.js
+++ b/Ship/Commands/Help.js
@@ -1,7 +1,7 @@
 const Command = require("../Command.js");
 
 helpCommand = new Command()
-.addHandler("","Lists all commands",
+.addHandler("","Lists help on all commands",
   function(_,message){
     let commandNames = Object.keys(this.commandSource.bindings),
         result = "";

--- a/Ship/Commands/Help.js
+++ b/Ship/Commands/Help.js
@@ -14,7 +14,7 @@ helpCommand = new Command()
     Command.basicReply(result,message);
   },Command.nArgs(0))
 
-.addHandler("{command}","Lists detailed help for the given command",
+.addHandler("_command_","Lists detailed help for the given command",
   function(paramaters,message){
     let commandName = paramaters[0];
     let result = buildDesciptions(commandName,this.commandSource.bindings[commandName],true);


### PR DESCRIPTION
Fix #1 
Re-formats the help command to appear as below:
![screenshot - 311216 - 15 25 14](https://cloud.githubusercontent.com/assets/3843106/21578240/5bd33762-cf70-11e6-86dc-96ccc947b970.png)
