### PR TITLE
Fix bot failing to respond to command with it's username

### DIFF
--- a/Ship/CommandSource.js
+++ b/Ship/CommandSource.js
@@ -22,10 +22,10 @@ class CommandSource {
     let commandName = tokens.shift();
     let atAt = commandName.indexOf("@");
     if(atAt !== -1){
-      let commandName = commandName.substr(0,atAt);
-      if (commanName.substr(atAt+1) !== this.botUsername){
+      if (commandName.substr(atAt+1) !== this.botUsername){
         return;
       }
+      commandName = commandName.substr(0,atAt);
     }
     commandName = commandName.toLowerCase();
     if(!(commandName in this.bindings)){


### PR DESCRIPTION
Fix #5
- `let commandName` on line 25 was shadowing the declaration on line 22, which threw an error there.
- `commanName` on line 26 was of course, a typo
- By updating the value of `commandName` before checking for the bot's username we lost it, so thats been moved after the check.
![screenshot - 010117 - 15 08 19](https://cloud.githubusercontent.com/assets/3843106/21581680/35e380ba-d034-11e6-90b3-d7a9f325424f.png)
