### PR TITLE
About command

### DIFF
--- a/Ship/Commands/About.js
+++ b/Ship/Commands/About.js
@@ -1,0 +1,45 @@
+const Command = require("../Command.js");
+const config = require("../../config.json");
+
+const exec = require('child_process').exec;
+
+let gitVersion;
+exec('git describe', function callback(error, stdout){
+   gitVersion = stdout.trim();
+});
+
+const reportString = (function(){
+  if(!config.admin.issues && !config.admin.creator){
+    return;
+  }
+  let reportString = "Report issues ";
+  if(config.admin.issues){
+    reportString += `on the [issue tracker](${config.admin.issues})`;
+    if(config.admin.creator){
+      reportString += " or ";
+    }
+  }
+  if(config.admin.creator){
+    reportString += `by contacting ${config.admin.creator}`;
+  }
+  return reportString;
+})();
+
+const aboutString = config.about.repo?`Visit the [project repo](${config.about.repo}) for more information`:undefined;
+
+const strings = [aboutString,reportString].filter(n=>n!==undefined).join("\n");
+
+const aboutCommand = new Command()
+.addHandler("","Displays information about the bot",
+  function(_,message){
+    message.connection.sendMessage({
+      chat_id:message.chat.id,
+      parse_mode:"Markdown",
+      text:`${config.about.botName} v${gitVersion}.\n${strings}`,
+      disable_web_page_preview:true,
+      display_notification:true
+    });
+  },Command.nArgs(0));
+
+
+module.exports = aboutCommand;

--- a/Ship/Commands/index.js
+++ b/Ship/Commands/index.js
@@ -1,0 +1,6 @@
+function bindCommands(commandMap,messageSource){
+  Object.keys(commandMap).forEach(name=>{
+    require(`./${commandMap[name]}.js`).bind(name,messageSource);
+  });
+}
+module.exports = {bindCommands};

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const Connection = require("./Ship/Connection.js");
 const MessageRouter = require("./Ship/MessageRouter.js");
 const CommandSource = require("./Ship/CommandSource.js");
 
-const helpCommand = require("./Ship/Commands/Help.js");
+const Commands = require("./Ship/Commands");
+
 const bindOurCommands = require("./Commands.js");
 
 const config = require("./config.json");
@@ -19,8 +20,15 @@ connection.getMe().then(me=>{
   console.log(`> Response. We are "${me.username}".`);
   console.log("> Binding commands to command source.");
   commandSource = new CommandSource(messageSource,me.username);
-  helpCommand.bind("help",commandSource);
+  Commands.bindCommands({
+    help:"Help",
+    about:"About"
+  },commandSource);
   bindOurCommands(commandSource);
   console.log("> Starting message source.");
   source.start();
+});
+
+process.on('unhandledRejection', err => {
+  console.log(`${new Date()} WARN: Unandled error in promise:`,err);
 });


### PR DESCRIPTION
Adds an `/about` command to Ship, Fixes #6.

Example response:
![screenshot - 010117 - 19 50 10](https://cloud.githubusercontent.com/assets/3843106/21582724/86fab69a-d05b-11e6-8ece-52b7082e23a2.png)

The version is generated from a git describe, and requires at least one tag to be present in the repository.
Everything else is from the config.

Also simplifies the method for binding ship's commands to the bot (since they are now 2)